### PR TITLE
Add streaming video for spectrum analyzer

### DIFF
--- a/Remote_Labs/video.ps1
+++ b/Remote_Labs/video.ps1
@@ -1,0 +1,32 @@
+# for PowerShell
+
+# You must be connected to remote lab West using Wireguard.
+
+# You must have a ~/.ssh/config entry for host labvideo:
+# Host labvideo
+#     HostName labvideo.sandiego.openresearch.institute
+#     User labvideo
+#     Port 22
+
+# You must have the program ffplay.exe installed on the PATH.
+
+$myip = Get-NetIPAddress | Where-Object { ($_.IPAddress.Length -Ge 9) -and ($_.IPAddress.SubString(0,8) -Eq "10.73.0.") } | select -ExpandProperty IPAddress
+$myport = 57373
+
+# make sure the IP address is plausible
+$last_octet = [int]($myip -Split "\.",4)[3]
+if ( ($last_octet -lt 1) -or ($last_octet -ge 255))
+{
+	echo "Implausible IP address $myip -- is Wireguard up?"
+	return
+}
+
+Start-Process -FilePath "ssh" -ArgumentList "labvideo ffmpeg -hide_banner -loglevel error -s 1280x720 -i /dev/video0 -f mpegts udp://${myip}:${myport}" -WindowStyle Hidden
+
+echo "Sending video to ${myip}:${myport}, type q into video window to quit"
+
+& 'ffplay.exe' -hide_banner -nostats -loglevel fatal -i udp://labvideo.sandiego.openresearch.institute:${myport}
+ 
+ssh labvideo pkill -e -f "ffmpeg.*udp://${myip}:${myport}"
+
+ 

--- a/Remote_Labs/video.sh
+++ b/Remote_Labs/video.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# You must be connected to remote lab West using Wireguard.
+# See Remote_Labs/ORI-Lab-User-Setup.md for more info.
+
+# You must have a ~/.ssh/config entry for host labvideo:
+# Host labvideo
+#     HostName labvideo.sandiego.openresearch.institute
+#     User labvideo
+#     Port 22
+
+# You must have ffplay available on the path.
+# sudo apt install ffmpeg
+
+
+if [[ $OSTYPE == 'linux'* ]]; then
+  myip=$(ip route get 10.73.1.1 | sed -n '/src/{s/.*src *\([^ ]*\).*/\1/p;q}')
+elif [[ $OSTYPE == 'darwin'* ]]; then
+  interface=$(route get 10.73.1.1 | grep interface: | sed s/"interface: "//)
+  myip=$(ifconfig $interface | grep --only-matching "10\\.73\\.\\d\\+\\.\\d\\+ --" | awk '{print $1}')
+else
+  myip=10.73.0.N	# replace N with your unique number!
+fi
+myport=57373
+
+# make sure the IP address is plausible
+if [[ ! $myip =~ ^10.73.0.[0-9]+$ ]]; then
+	echo "Implausible IP address $myip -- is Wireguard up?"
+	exit 1
+fi
+
+ssh -f labvideo ffmpeg -hide_banner -loglevel error -s 1280x720 -i /dev/video0 -f mpegts udp://${myip}:${myport}
+echo Sending video to ${myip}:${myport}, type q into video window to quit \(or ^C here\).
+ffplay -hide_banner -nostats -loglevel fatal -i udp://localhost:${myport}
+ssh labvideo pkill -e -f "ffmpeg.*udp://${myip}:${myport}"
+wait


### PR DESCRIPTION
This adds two scripts (one for bash, one for PowerShell) and updates the Video-SA.md document to replace the old method of viewing the spectrum analyzer's screen with streaming video.

Resolves #44 