### PR TITLE
Update guide to viewing/controlling the spectrum analyzer

### DIFF
--- a/Remote_Labs/ORI-Lab-User-Setup.md
+++ b/Remote_Labs/ORI-Lab-User-Setup.md
@@ -601,4 +601,4 @@ Not recommended. If you insist, details can be found in [Setting Up for X11 Forw
 
 ## Support
 
-You can always email the lab managers at [remote-labs@openresearch.institute](mailto:remote-labs@openresearch.institute) with any questions or suggestions. You can also find us, more often than not, in the **Phase 4 Ground** Slack in the **remote_labs** channel.
+You can always email the lab managers at [remote-labs@openresearch.institute](mailto:remote-labs@openresearch.institute) with any questions or suggestions. You can also find us, more often than not, in Slack in the **remote_labs** channel.

--- a/Remote_Labs/README.md
+++ b/Remote_Labs/README.md
@@ -20,5 +20,5 @@ Ham Expo in March 2021, _Remote Labs for P4XT Engineering Development_.
 ## Lab Notes
 
 * [Getting Screenshots](Getting%20Screenshots.md) (Python scripting tutorial)
-* [Spectrum Analyzer Video](Video-SA.md) (using video streaming)
+* [Spectrum Analyzer Control/Video](Video-SA.md) (using web app or video streaming)
 * [Creating a Linux VM](new-Linux-VM-on-Chonc.txt) (Lab Manager's notes)

--- a/Remote_Labs/README.md
+++ b/Remote_Labs/README.md
@@ -20,5 +20,5 @@ Ham Expo in March 2021, _Remote Labs for P4XT Engineering Development_.
 ## Lab Notes
 
 * [Getting Screenshots](Getting%20Screenshots.md) (Python scripting tutorial)
-* [Spectrum Analyzer Video](Video-SA.md) (using X11 forwarding)
+* [Spectrum Analyzer Video](Video-SA.md) (using video streaming)
 * [Creating a Linux VM](new-Linux-VM-on-Chonc.txt) (Lab Manager's notes)

--- a/Remote_Labs/Video-SA.md
+++ b/Remote_Labs/Video-SA.md
@@ -1,5 +1,17 @@
 # ORI Remote Labs: Spectrum Analyzer Video
 
+## You Probably Don't Need Video Streaming Anymore
+
+As of firmware version 00.03.06 of the RSA5065N Spectrum Analyzer, there is a much better way to remotely access the instrument. It now supports an internal web page that not only displays the screen in real time, but also allows full control of the instrument through the browser. If you already have Wireguard set up, you can just access http://rsa5065n.sandiego.openresearch.institute and go. (Note: http not https)
+
+One special trick you need: in order to access functions that would require pressing physical buttons on the front panel of the spectrum analyzer, use the on-screen button in the top row that looks like four buttons.
+
+Now that you can control the spectrum analyzer and not just view its screen, there is a possibility that you might interfere with other users. Please be aware of this possibility and coordinate on Slack if in doubt.
+
+That said, the video stream from `labvideo.sandiego.openresearch.institute` remains available and you can still use that if you prefer. Read on for more details.
+
+## Original Introduction
+
 Of all the instruments in the lab, the RSA5065N Spectrum Analyzer has the largest and richest screen display. The size of the display makes screenshots slow. Moreover, for many lab purposes it's quite revealing to see the spectrum display changing in real time, and not really satisfactory to get only a still screenshot.
 
 The RSA5065N has an HDMI video output port. We have an inexpensive HDMI capture device connected between that HDMI output and a USB port on a Raspberry Pi. With just a little extra setup, you can use this to get a live view of the spectrum analyzer's screen. It won't be quite as quick as the instrument's actual front panel, but will still be far more useful than static screenshots.

--- a/Remote_Labs/Video-SA.md
+++ b/Remote_Labs/Video-SA.md
@@ -2,7 +2,7 @@
 
 Of all the instruments in the lab, the RSA5065N Spectrum Analyzer has the largest and richest screen display. The size of the display makes screenshots slow. Moreover, for many lab purposes it's quite revealing to see the spectrum display changing in real time, and not really satisfactory to get only a still screenshot.
 
-The RSA5065N has an HDMI video output port. We have an inexpensive HDMI capture device connected between that HDMI output and a USB port on a Raspberry Pi. With just a little extra setup, you can use this to get a live view of the spectrum analyzer's screen. It won't be quite as quick as the instrument's actual front panel, but will still be more useful than static screenshots.
+The RSA5065N has an HDMI video output port. We have an inexpensive HDMI capture device connected between that HDMI output and a USB port on a Raspberry Pi. With just a little extra setup, you can use this to get a live view of the spectrum analyzer's screen. It won't be quite as quick as the instrument's actual front panel, but will still be far more useful than static screenshots.
 
 Unfortunately, none of the other instruments has a video output port, so this only works on the spectrum analyzer.
 


### PR DESCRIPTION
Until recently we had view-only access to the screen of the spectrum analyzer, by capturing video from the HDMI output of the instrument. Originally, we recommended opening a remote GUI desktop on the main Raspberry Pi, and using a video viewing program to view the captured video. Later, we moved the video to a separate Raspberry Pi and recommended using ffmpeg to create a unicast UDP stream of the video, which could be received over the Wireguard network.

Now, after a firmware update on the spectrum analyzer, we are able to both view and control the spectrum analyzer using a built-in web app capability. This pull request changes the document on viewing the spectrum analyzer screen by adding information about the web app, without removing the instructions for streaming video.

There are also a few unrelated wording tweaks included.